### PR TITLE
Tidy up schema awareness dependencies in "as" test set

### DIFF
--- a/tests/attr/as/_as-test-set.xml
+++ b/tests/attr/as/_as-test-set.xml
@@ -10,6 +10,13 @@
       <schema role="stylesheet-import" file="variousTypesSchemaAs.xsd"/>
    </environment>
    
+   <environment name="as-01b">
+      <source role="." validation="skip">
+         <content><![CDATA[<doc/>]]></content>
+      </source>
+      <source file="simple.xml" uri="simple.xml" validation="skip"/>
+   </environment>
+   
    <environment name="as-03">
       <source role=".">
          <content><![CDATA[<doc>
@@ -137,7 +144,8 @@ a:_underscore_
       <description>Test with global xsl:variable and @as=empty-sequence(). Value for @select are () and empty sequence obtained at run time.</description>
       <keywords>instance-of empty-sequence xs:string SequenceType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -157,7 +165,8 @@ a:_underscore_
       </description>
       <keywords>empty-sequence SequenceType xs:string xs:double xs:boolean xs:dayTimeDuration xs:date</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -174,7 +183,8 @@ a:_underscore_
          Test with xsl:function and @as=empty-sequence(). Use xsl:sequence with @select=() inside the sequence constructor.</description>
       <keywords>empty-sequence xsl:function SequenceType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -193,7 +203,8 @@ a:_underscore_
       </description>
       <keywords>empty-sequence instance-of xs:string SequenceType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -212,7 +223,8 @@ a:_underscore_
       </description>
       <keywords>xs:untypedAtomic text-conversion AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -232,7 +244,8 @@ a:_underscore_
       <keywords>xs:anyAtomicType buildin-datatypes conversion AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
       <modified by="Abel Braaksma" on="2014-10-31" change="Bug 27216, adding high/low year dependencies"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support negative year" satisfied="true"/>
@@ -255,7 +268,8 @@ a:_underscore_
       </description>
       <keywords>xs:anyAtomicType buildin-datatypes conversion AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support negative year" satisfied="false"/>
@@ -278,7 +292,8 @@ a:_underscore_
       </description>
       <keywords>xs:anyAtomicType buildin-datatypes conversion AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -297,7 +312,8 @@ a:_underscore_
       </description>
       <keywords>xs:anyAtomicType mixed-sequence conversion empty-sequence AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -316,7 +332,8 @@ a:_underscore_
       </description>
       <keywords>xs:anyAtomicType conversion AtomicOrUnionType OccurrenceIndicator mixed-sequence</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -334,7 +351,8 @@ a:_underscore_
       </description>
       <keywords>xs:anyAtomicType sequence AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -354,7 +372,8 @@ a:_underscore_
       <keywords>buildin-types conversion-to-self AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
       <modified by="Abel Braaksma" on="2014-10-31" change="Bug 27216, adding high/low year dependencies"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support negative year" satisfied="true"/>
@@ -377,7 +396,8 @@ a:_underscore_
       </description>
       <keywords>buildin-types conversion-to-self AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support year above 9999" satisfied="false"/>
@@ -400,7 +420,8 @@ a:_underscore_
       </description>
       <keywords>buildin-types conversion-to-self AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -421,7 +442,8 @@ a:_underscore_
       <keywords>buildin-types conversion-to-self instance-of AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
       <modified by="Abel Braaksma" on="2014-10-31" change="Bug 27216, adding high/low year dependencies"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support year above 9999" satisfied="true"/>
@@ -445,7 +467,8 @@ a:_underscore_
       </description>
       <keywords>buildin-types conversion-to-self instance-of AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support year above 9999" satisfied="false"/>
@@ -469,7 +492,8 @@ a:_underscore_
       </description>
       <keywords>buildin-types conversion-to-self instance-of AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -490,7 +514,8 @@ a:_underscore_
       <keywords>buildin-types conversion-to-self xsl:value-of AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
       <modified by="Abel Braaksma" on="2014-10-31" change="Bug 27216, adding high/low year dependencies"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support year above 9999" satisfied="true"/>
@@ -552,7 +577,8 @@ a:_underscore_
       </description>
       <keywords>buildin-types conversion-to-self xsl:value-of AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <year_component_values value="support year above 9999" satisfied="false"/>
@@ -576,7 +602,8 @@ a:_underscore_
       </description>
       <keywords>buildin-types conversion-to-self xsl:value-of AtomicOrUnionType</keywords>
       <created by="Abel Braaksma" on="2014-10-31"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -630,7 +657,8 @@ a:_underscore_
       <description>Test with xsl:function where where the value in the sequence constructor is explicitly constructed and of the same type as the built-in atomic type in @as. Types tested are: - xs:string, xs:double, xs:integer, xs:dayTimeDuration, xs:QName</description>
       <keywords>buildin-types conversion-to-self xsl:function AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -646,7 +674,8 @@ a:_underscore_
       <description>Test type of global xsl:variable where @select contains an xs:float, xs:decimal or xs:integer, @as="xs:double".(type promotion)</description>
       <keywords>type-promotion xs:float xs:double xs:decimal xs:integer AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -662,7 +691,8 @@ a:_underscore_
       <description>Test type of global xsl:variable where @select contains an xs:decimal or xs:integer, @as="xs:float".(type promotion)</description>
       <keywords>type-promotion xs:float xs:decimal xs:integer AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -678,7 +708,8 @@ a:_underscore_
       <description>Test type of global xsl:variable where @select contains an xs:anyURI, @as="xs:string".(type promotion)</description>
       <keywords>type-promotion xs:anyUri xs:string AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -694,7 +725,8 @@ a:_underscore_
       <description>Test type of global xsl:variable where @select contains an xs:integer, @as="xs:decimal".(subtype substitution)</description>
       <keywords>subtype-substitution xs:decimal xs:integer AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -710,7 +742,8 @@ a:_underscore_
       <description>Test type of global xsl:variable where @select contains an xs:dayTimeDuration or xs:yearMonthDuration, @as="xs:duration".(subtype substitution)</description>
       <keywords>subtype-substitution xs:duration xs:dayTimeDuration xs:yearMonthDuration AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -729,7 +762,8 @@ a:_underscore_
       <description>Test with an empty sequence obtained at run time in @select of global xsl:variable and @as is a built-in atomic type with occurence indicator (?). Verify the variable is of the type specified in @as.Values for @as tested: all built-in primitive types (except xs:QName), xs:integer, xs:dayTimeDuration, xs:yearMonthDuration</description>
       <keywords>empty-sequence buildin-types AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -745,7 +779,8 @@ a:_underscore_
       <description>Test with xsl:variable where the value in @select is (), the built-in primitive type in @as has occurence indicator (?). Values for @as tested: all built-in primitive types (except xs:QName), xs:integer, xs:dayTimeDuration, xs:yearMonthDuration</description>
       <keywords>empty-sequence buildin-types AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -761,7 +796,8 @@ a:_underscore_
       <description>Test with xsl:template which constructs the empty sequence () and @as is a built-in type use occurence indicator (?). Values for @as tested: all built-in primitive types (except xs:QName), xs:integer, xs:dayTimeDuration, xs:yearMonthDuration</description>
       <keywords>empty-sequence buildin-types AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -777,7 +813,8 @@ a:_underscore_
       <description>Test with xsl:function that constructs an xs:dayTimeDuration value as a child of LRE and has @as=xs:dayTimeDuration?. Verify the returned value if of type xs:dayTimeDuration?.</description>
       <keywords>lre-promotion xs:dayTimeDuration AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -793,7 +830,8 @@ a:_underscore_
       <description>Test with an xs:anyURI value as a child of LRE in the sequence constructor of a global xsl:param and @as=xs:anyURI+. Verify the parameter is of type xs:anyURI+.</description>
       <keywords>lre-promotion xs:anyURI AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -809,7 +847,8 @@ a:_underscore_
       <description>Test with a local xsl:param, where @select is an empty sequence obtained at run time and @as=xs:double*. Verify the parameter is of type xs:double*.</description>
       <keywords>empty-sequence xs:double AtomicOrUnionType OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -825,7 +864,8 @@ a:_underscore_
       <description>Test type of global xsl:variable without @select and @as="document-node()". Sequence constructor contains an xsl:document instruction.</description>
       <keywords>xsl:document DocumentTest</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -841,7 +881,8 @@ a:_underscore_
       <description>Test type of global xsl:variable without @select and @as="element()". Sequence constructor contains an xsl:element instruction or an LRE.</description>
       <keywords>xsl:element ElementTest</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -857,7 +898,8 @@ a:_underscore_
       <description>Test type of result of xsl:function that has @as="element(QName, xs:untyped)" and sequence constructor contains xsl:element or an LRE.</description>
       <keywords>lre xs:untyped ElementTest ElementName TypeName</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -873,7 +915,8 @@ a:_underscore_
       <description>Test type of result of xsl:function that has @as="attribute() and sequence constructor contains xsl:attribute.</description>
       <keywords>xsl:attribute AttributeTest</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -890,7 +933,8 @@ a:_underscore_
       <keywords>xsl:document DocumentTest OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
       <modified by="Abel Braaksma" on="2013-12-10" change="Added dependency to XSLT20+ instead of schema_aware"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -909,7 +953,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="element(QName)*" and returns the empty sequence, a sequence of xsl:element or LREs.</description>
       <keywords>xsl:element ElementTest ElementName OccurrenceIndicator empty-sequence</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -933,7 +978,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="element(*)+" and returns a sequence of xsl:element or LREs.</description>
       <keywords>xsl:element ElementTest ElementNameOrWildcard OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -957,7 +1003,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="element(*, xs:untyped)+" and returns a sequence of xsl:element or LREs.</description>
       <keywords>xsl:element ElementTest ElementNameOrWildcard TypeName OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -981,7 +1028,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="attribute(QName, xs:untypedAtomic)*" and returns the empty sequence or a sequence of xsl:attribute.</description>
       <keywords>xsl:attribute empty-sequence AttributeTest AttributeName TypeName OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -997,7 +1045,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="attribute()?" and returns the empty sequence or an xsl:attribute.</description>
       <keywords>xsl:attribute empty-sequence AttributeTest AttributeName TypeName OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1013,7 +1062,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="attribute(*, xs:untypedAtomic)?" and returns the empty sequence or an xsl:attribute.</description>
       <keywords>xsl:attribute empty-sequence AttributeTest AttributeNameOrWildcard TypeName OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1030,7 +1080,8 @@ a:_underscore_
       <keywords>xsl:function empty-sequence DocumentTest OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
       <modified by="Michael Kay" on="2012-12-11" change="changed argument to doc() function, see bug 20021"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1046,7 +1097,8 @@ a:_underscore_
       <description>Test with xsl:function that has @as="element()*" and returns: -an empty sequence, one xsl:element node, a sequence of xsl:element nodes</description>
       <keywords>xsl:function empty-sequence ElementTest OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1062,7 +1114,8 @@ a:_underscore_
       <description>Test with xsl:function that has @as="attribute()?", and returns nothing or an xsl:attribute.</description>
       <keywords>xsl:function empty-sequence AttributeTest OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1078,7 +1131,8 @@ a:_underscore_
       <description>Test type of global xsl:variable that has @as="item()?" and no @select, the sequence constructor contains one of: - nothing, LRE, xsl:value-of, xsl:element, xsl:attribute</description>
       <keywords>xsl:variable ItemTest OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1094,7 +1148,8 @@ a:_underscore_
       <description>Test with xsl:template that has @as="item()" and the sequence constructor contains one of: - LRE, xsl:value-of, xsl:sequence with one item, xsl:element, xsl:document</description>
       <keywords>xsl:template ItemTest</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1110,7 +1165,8 @@ a:_underscore_
       <description>Test with xsl:function that has @as="item()*" and the sequence constructor contains one of: -nothing, LREs, xsl:value-of, xsl:sequence, sequence of xsl:element, xsl:document</description>
       <keywords>xsl:function ItemTest OccurrenceIndicator</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
       </dependencies>
@@ -1133,10 +1189,12 @@ a:_underscore_
       <description>Test with xsl:template which contains an explicitly constructed typed value and @as="xs:anyAtomicType". Types tested: - derived built-in atomic type, user-defined atomic type</description>
       <keywords>xs:anyAtomicType AtomicOrUnionType xsl:template</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Add dependency on schema awareness"/>
       <environment ref="as-01"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
+         <feature value="schema_aware"/>
       </dependencies>
       <test>
          <stylesheet file="as-0142.xsl"/>
@@ -1150,7 +1208,8 @@ a:_underscore_
       <description>Test with global xsl:variable without @select, where sequence constructor contains an explicitly constructed typed value of the same type as the built-in derived atomic type in @as. Verify the variable is of the type specified in @as.</description>
       <keywords>xsl:variable buildin-datatypes AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
@@ -1167,7 +1226,8 @@ a:_underscore_
       <description>Test of global xsl:variable with a sequence constructor of LREs and @as= built-in derived atomic type. Value of LRE is in the lexical space of the type in @as. Verify the variable is of the type specified in @as.</description>
       <keywords>lre-promotion buildin-datatypes AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
@@ -1184,7 +1244,8 @@ a:_underscore_
       <description>Test of global xsl:param with a sequence constructor of LREs and @as= built-in derived atomic type. Value of LRE is in the lexical space of the type in @as. Verify the variable is of the type specified in @as.</description>
       <keywords>lre-promotion buildin-datatypes AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2016-01-29"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
@@ -1201,7 +1262,8 @@ a:_underscore_
       <description>Test of xsl:template with a sequence constructor of LREs and @as= built-in derived atomic type. Value of LRE is in the lexical space of the type in @as.</description>
       <keywords>lre-promotion buildin-datatypes AtomicOrUnionType xsl:template</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
@@ -1239,7 +1301,8 @@ a:_underscore_
       <description>Test with xsl:function where the value in the sequence constructor is explicitly constructed and is of the same type as the built-in derived atomic type in @as. Types tested are: -xs:nonPositiveInteger, xs:int, xs:long, xs:unsignedByte, xs:NMTOKEN, xs:ID. Verify the result of the function is of the type specified in @as.</description>
       <keywords>xsl:function xs:long xs:int xs:unsignedByte xs:NMTOKEN xs:ID xs:nonPositiveInteger AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
-      <environment ref="as-01"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Use environment without schema"/>
+      <environment ref="as-01b"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
@@ -1294,10 +1357,12 @@ a:_underscore_
       <description>Test with xsl:function where the value in the sequence constructor is explicitly constructed and is of the same type as the user-defined atomic type (derived by restriction) in @as. Verify the result of the function is of the type specified in @as.</description>
       <keywords>xsl:import-schema user-defined-atomic-type xsl:function AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Add dependency on schema awareness"/>
       <environment ref="as-01"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
+         <feature value="schema_aware"/>
       </dependencies>
       <test>
          <stylesheet file="as-0149.xsl"/>
@@ -1311,10 +1376,12 @@ a:_underscore_
       <description>Test with xsl:function that returns an empty sequence and has @as=xs:NMTOKEN*. Verify the returned value if of type xs:NMTOKEN*.</description>
       <keywords>xsl:function xs:NMTOKEN AtomicOrUnionType</keywords>
       <created by="Michael Kay" on="2012-10-30"/>
+      <modified by="Debbie Lockett" on="2020-10-14" change="Add dependency on schema awareness"/>
       <environment ref="as-01"/>
       <dependencies>
          <spec value="XSLT20+"/>
          <feature value="built_in_derived_types"/>
+         <feature value="schema_aware"/>
       </dependencies>
       <test>
          <stylesheet file="as-0150.xsl"/>


### PR DESCRIPTION
Update as-test-set: use new modified environment as-01b which does not include schema as appropriate; ensure tests which do use schema specify schema_aware dependency