### PR TITLE
Add test for qtspecs issue #21

### DIFF
--- a/tests/decl/output/_output-test-set.xml
+++ b/tests/decl/output/_output-test-set.xml
@@ -4954,6 +4954,23 @@
          </all-of>
       </result>
    </test-case>
-   
 
+   <test-case name="output-0724">
+      <description>Test serialization of input/@value</description>
+      <created by="Norman Walsh" on="2020-12-22"/>
+      <dependencies>
+         <spec value="XSLT20+"/>
+      </dependencies>
+      <test>
+         <stylesheet file="output-0724.xsl"/>
+         <output serialize="yes"/>
+      </test>
+      <result>
+        <any-of>
+          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input value="✈"/>$]]></serialization-matches>
+          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input type="text" value="✈"/>$]]></serialization-matches>
+          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input value="✈" type="text"/>$]]></serialization-matches>
+        </any-of>
+      </result>
+   </test-case>
 </test-set>

--- a/tests/decl/output/output-0724.xsl
+++ b/tests/decl/output/output-0724.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:output method="html" html-version="5"/>
+
+  <xsl:template name="xsl:initial-template">
+    <input type="text" value="✈"/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
> In Appendix D of the Serialization 3.1 specification (also 3.0), input/@​value is listed as a URI attribute subject to %HH escaping. However, this attribute does not typically contain a URI, it is not listed in the HTML DTD as being of type %uri, and if it is sent to the browser in %-escaped form, it will not be unescaped prior to display.

See https://github.com/w3c/qtspecs/issues/21