### PR TITLE
Fix typo in output-0724

### DIFF
--- a/tests/decl/output/_output-test-set.xml
+++ b/tests/decl/output/_output-test-set.xml
@@ -4967,9 +4967,9 @@
       </test>
       <result>
         <any-of>
-          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input value="✈"/>$]]></serialization-matches>
-          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input type="text" value="✈"/>$]]></serialization-matches>
-          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input value="✈" type="text"/>$]]></serialization-matches>
+          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input value="✈">$]]></serialization-matches>
+          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input type="text" value="✈">$]]></serialization-matches>
+          <serialization-matches><![CDATA[^(<!DOCTYPE (HTML|html)>\s*)?<input value="✈" type="text">$]]></serialization-matches>
         </any-of>
       </result>
    </test-case>


### PR DESCRIPTION
Apologies, in my previous PR for output-0724 I committed an incorrect test result. This PR fixes that error.

(The stylesheet uses HTML serialization, so the expected results must also use HTML serialization.)
