### PR TITLE
date test set minor fixes

### DIFF
--- a/tests/type/date/_date-test-set.xml
+++ b/tests/type/date/_date-test-set.xml
@@ -1739,7 +1739,6 @@
       <dependencies>
          <spec value="XSLT30+"/>
          <year_component_values satisfied="true" value="support negative year"/>
-         <year_component_values satisfied="true" value="support year zero"/>
       </dependencies>
       <test>
          <stylesheet file="date-094.xsl"/>
@@ -2032,7 +2031,6 @@
       <dependencies>
          <spec value="XSLT30+"/>
          <year_component_values satisfied="true" value="support negative year"/>
-         <year_component_values satisfied="true" value="support year zero"/>
       </dependencies>
       <test>
          <stylesheet file="date-095.xsl"/>


### PR DESCRIPTION
Remove unnecessary year_component_values "support year zero" dependency from two tests