### PR TITLE
Fix a bug in test streaming-fallback-004, revealed by fixing Saxon bug 4920

### DIFF
--- a/tests/misc/streaming-fallback/_streaming-fallback-test-set.xml
+++ b/tests/misc/streaming-fallback/_streaming-fallback-test-set.xml
@@ -56,12 +56,15 @@
          Initial-value expression is not motionless. Error case when streaming.
       </description>
       <created by="Michael Kay" on="2018-01-08"/>
+      <modified by="Michael Kay" on="2021-03-16" 
+         change="Test failed because the result of select='//x' is an empty sequence, which
+         is not permitted by the @as attribute on accumulator name='count'"/>
       <environment>
          <source role="." file="../../decl/accumulator/accumulator-004.xml" streaming="true"/>
       </environment>
       <test>
          <stylesheet file="../../decl/accumulator/accumulator-007.xsl"/>
-         <param name="initial-count" as="xs:string" select="'//x'" static="yes"/>
+         <param name="initial-count" as="xs:string" select="'xs:integer(xs:decimal(//transaction[9]/@amount))'" static="yes"/>
          <param name="streamable" static="yes" select="'yes'"/>
       </test>
       <result>


### PR DESCRIPTION
Fix a bug in test streaming-fallback-004, revealed when Saxon bug 4920 was fixed. Saxon was doing inadequate type checking on accumulators, which resulted in the error in this test case not being picked up.