### PR TITLE
Fix test: attribute order is implementation dependent

### DIFF
--- a/tests/decl/variable/_variable-test-set.xml
+++ b/tests/decl/variable/_variable-test-set.xml
@@ -633,7 +633,10 @@
          <stylesheet file="variable-0501.xsl"/>
       </test>
       <result>
-         <assert-xml><![CDATA[<out><book><nodes>1</nodes><copy><t>1 4097 Chapter 1 2 3105 Chapter 2</t></copy></book></out>]]></assert-xml>
+         <any-of>
+            <assert-xml><![CDATA[<out><book><nodes>1</nodes><copy><t>1 4097 Chapter 1 2 3105 Chapter 2</t></copy></book></out>]]></assert-xml>
+            <assert-xml><![CDATA[<out><book><nodes>1</nodes><copy><t>4097 1 Chapter 1 3105 2 Chapter 2</t></copy></book></out>]]></assert-xml>
+         </any-of>
       </result>
    </test-case>
 

--- a/tests/decl/variable/_variable-test-set.xml
+++ b/tests/decl/variable/_variable-test-set.xml
@@ -625,6 +625,7 @@
    <test-case name="variable-0501">
       <description>Bug in Saxon 9.2: xsl:value-of generating multiple text nodes</description>
       <created by="Michael Kay" on="2012-11-07"/>
+      <modified by="Erik Hetzner" on="2026-05-09" change="make results independent of attribute order"/>       
       <environment ref="variable-05"/>
       <dependencies>
          <spec value="XSLT20+"/>


### PR DESCRIPTION
xjslt gives a different result because the attributes are returned in a different order